### PR TITLE
fixes the case of ignoreInstance=false, ignoreProcess=true

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -55,7 +55,7 @@ function Network (options) {
 
                 //self.emit("error", err);
             }
-            else if (obj.pid == procUuid && self.ignoreProcess) {
+            else if (obj.pid == procUuid && self.ignoreProcess && obj.iid !== self.instanceUuid) {
                     return false;
             }
             else if (obj.iid == self.instanceUuid && self.ignoreInstance) {


### PR DESCRIPTION
Before the change, if you set `{ignoreInstance: false, ignoreProcess:true}` or even just `{ignoreInstance: false}`, it will still ignore messages from the instance because it's from the process. 
This way you can receive messages from the same instance while still ignoring messages from other instances in the process.
You can also set `{ignoreInstance: false}` without also setting the `ignoreProcess` flag if you don't have other instances in the same process.