### PR TITLE
Added initialAdvertisement option to constructor parameters.

### DIFF
--- a/lib/discover.js
+++ b/lib/discover.js
@@ -39,18 +39,18 @@ var reservedEvents = ['promotion', 'demotion', 'added', 'removed', 'master', 'he
 module.exports = Discover;
 
 /*
- * This is the default automatically assigned weight function in the case that 
+ * This is the default automatically assigned weight function in the case that
  * you do not specify a weight, this function will be called. You can override
  * this function if you want to change the default behavior.
- * 
+ *
  * Example:
- * 
+ *
  * ```js
  * var Discover = require('discover');
  * Discover.weight = function () {
  * 	return Math.random();
  * }
- * 
+ *
  * var d = new Discover();
  * ```
  */
@@ -127,7 +127,8 @@ function Discover (options, callback) {
 		isMaster 	: false,
 		isMasterEligible: self.settings.server, //Only master eligible by default if we are a server
 		weight 		: settings.weight,
-		address 	: '127.0.0.1' //TODO: get the real local address?
+		address 	: '127.0.0.1', //TODO: get the real local address?
+		advertisement: options.initialAdvertisement
 	};
 
 	self.nodes = {};
@@ -210,15 +211,15 @@ function Discover (options, callback) {
 		for (var processUuid in self.nodes) {
 			node = self.nodes[processUuid];
 			removed = false;
-	
+
 			if ( +new Date() - node.lastSeen > settings.nodeTimeout ) {
 				//we haven't seen the node recently
-	
+
 				//If node is a master and has not timed out yet based on the masterTimeout then fake it being found
 				if ( node.isMaster && (+new Date() - node.lastSeen) < settings.masterTimeout ) {
 					mastersFound++;
 				}
-	
+
 				//delete the node from our nodes list
 				delete self.nodes[processUuid]
 				removed = true;
@@ -227,12 +228,12 @@ function Discover (options, callback) {
 			else if (node.isMaster) {
 				mastersFound++;
 			}
-	
+
 			if (node.weight > self.me.weight && node.isMasterEligible && !node.isMaster && !removed) {
 				higherWeightFound = true;
 			}
 		}
-	
+
 		if (!self.me.isMaster && mastersFound < settings.mastersRequired && self.me.isMasterEligible && !higherWeightFound) {
 			//no masters found out of all our nodes, become one.
 			self.promote();
@@ -245,7 +246,7 @@ function Discover (options, callback) {
 
 			return false;
 		}
-		
+
 		self.broadcast.start(function (err) {
 			if (err) {
 				return callback && callback(err, false);


### PR DESCRIPTION
I was trying to define node types with advertised objects, so it's better to able to assign it before calling `Discover.prototype.start`.