### PR TITLE
Resolve issue with default broadcast addresses

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -94,8 +94,34 @@ Network.prototype.start = function (callback) {
             //Default to using broadcast if multicast address is not specified.
             self.socket.setBroadcast(true);
 
-            //TODO: get the default broadcast address from os.networkInterfaces() (not currently returned)
-            self.destination = [self.broadcast || "255.255.255.255"];
+            /**
+             * Get broadcast addresses for all network interfaces instead 255.255.255.255
+             * because of issues with broadcast using this method on Windows
+             */
+            var networkInterfaces = os.networkInterfaces(),
+                broadcastAddresses = [];
+
+            Object.keys(networkInterfaces).forEach(function (ifname) {
+                networkInterfaces[ifname].forEach(function (iface) {
+                    if ('IPv4' !== iface.family || iface.internal !== false) {
+                        // skip over internal (i.e. 127.0.0.1) and non-ipv4 addresses
+                        return;
+                    }
+
+                    var tabytes = (iface.address).split("."),
+                        tsbytes = (iface.netmask).split(".");
+
+                    // Calculate Broadcast address
+                    var tbaddr = ((tabytes[0] & tsbytes[0]) | (255 ^ tsbytes[0])) + "."
+                        + ((tabytes[1] & tsbytes[1]) | (255 ^ tsbytes[1])) + "."
+                        + ((tabytes[2] & tsbytes[2]) | (255 ^ tsbytes[2])) + "."
+                        + ((tabytes[3] & tsbytes[3]) | (255 ^ tsbytes[3]));
+
+                    broadcastAddresses.push(tbaddr);
+                });
+            });
+
+            self.destination = self.broadcast ? self.broadcast : broadcastAddrs;
         }
         else {
             try {


### PR DESCRIPTION
Use list of network interfaces in order to find broadcast addresses for each interface and use them instead 255.255.255.255 because of issues on Windows: see thread [How to fix the global broadcast address (255.255.255.255) behavior on Windows?](https://social.technet.microsoft.com/Forums/windows/en-US/72e7387a-9f2c-4bf4-a004-c89ddde1c8aa/how-to-fix-the-global-broadcast-address-255255255255-behavior-on-windows?forum=w7itpronetworking)