### PR TITLE
Refactor the leadership module to make use of existing and new events

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -19,23 +19,23 @@ var d = new Discover({
 console.log('I am ' + d.broadcast.instanceUuid);
 
 d.on("added", function (obj) {
-	console.log("New node discovered on the network.");
+	process.stdout.write("\nNew node discovered on the network.");
 	//console.log(obj);
 	prompt();
 });
 
 d.on("promotion", function (obj) {
-	console.log("I was promoted");
+	process.stdout.write("\nI was promoted");
 	prompt();
 });
 
 d.on("demotion", function (obj) {
-	console.log('I was demoted');
+	process.stdout.write("\nI was demoted");
 	prompt();
 });
 
 d.on("removed", function (obj) {
-	console.log("Node lost from the network.");
+	process.stdout.write("\nNode lost from the network.");
 	//console.log(obj);
 	prompt();
 });
@@ -48,6 +48,10 @@ d.on("error", function (err) {
 // d.broadcast.on("hello", function (obj) {
 // 	console.log(obj);
 // });
+console.log('')
+console.log('************************************************');
+console.log('commands: promote, demote, demote true, list, me');
+console.log('************************************************');
 
 prompt()
 

--- a/examples/master.js
+++ b/examples/master.js
@@ -10,7 +10,11 @@
 
 var Discover = require("../");
 
-var d = new Discover({ key : process.argv[2], weight : Date.now() * -1, mastersRequired : 2 });
+var d = new Discover({ 
+	key : process.argv[2], weight : Date.now() * -1
+	, mastersRequired : 2
+	//, leadershipElector : Discover.NoLeadershipElection
+});
 
 console.log('I am ' + d.broadcast.instanceUuid);
 

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -101,9 +101,8 @@ function Discover (options, callback) {
 		ignoreInstance : (options.ignoreInstance ===  false) ? false : true
 	};
 
-	self.leadershipElector = (settings.leadershipElector) 
-		? new settings.leadershipElector(self)
-		: new leadership.BasicLeadershipElection(self);
+	//resolve the leadershipElector
+	self.leadershipElector = leadership(self.leadershipElector, self);
 
 	//this is for backwards compatibilty with v0.1.0
 	//TODO: should be removed in the next major release
@@ -246,7 +245,7 @@ function Discover (options, callback) {
 				self.hello();
 			}
 
-			self.emit('started');
+			self.emit('started', self);
 
 			return callback && callback(null, true);
 		});
@@ -262,7 +261,7 @@ function Discover (options, callback) {
 		clearInterval(checkId);
 		clearInterval(helloId);
 
-		self.emit('stopped');
+		self.emit('stopped', self);
 
 		running = false;
 	};

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -97,8 +97,9 @@ function Discover (options, callback) {
 		client			: options.client			|| (!options.client && !options.server),
 		server			: options.server			|| (!options.client && !options.server),
 		reuseAddr		: options.reuseAddr, 		//default is set at the network layer (true)
-		ignoreProcess : (options.ignoreProcess ===  false) ? false : true,
-		ignoreInstance : (options.ignoreInstance ===  false) ? false : true
+		ignoreProcess   : (options.ignoreProcess ===  false) ? false : true,
+		ignoreInstance  : (options.ignoreInstance ===  false) ? false : true,
+		start           : (options.start === false) ? false : true
 	};
 
 	//resolve the leadershipElector
@@ -266,7 +267,10 @@ function Discover (options, callback) {
 		running = false;
 	};
 
-	self.start(callback);
+	//check if auto start is enabled
+	if (self.settings.start) {
+		self.start(callback);
+	}
 
 	function helloInterval () {
 		if (typeof settings.helloInterval === 'function') {

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -61,9 +61,8 @@ Discover.weight = function () {
 };
 
 //expose the leadership election types
-Object.keys(leadership).forEach(function (type) {
-	Discover[type] = leadership[type];
-});
+Discover.BasicLeadershipElection = leadership.BasicLeadershipElection;
+Discover.NoLeadershipElection = leadership.NoLeadershipElection;
 
 function Discover (options, callback) {
 	if (!(this instanceof Discover)) {

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -101,6 +101,10 @@ function Discover (options, callback) {
 		ignoreInstance : (options.ignoreInstance ===  false) ? false : true
 	};
 
+	self.leadershipElector = (settings.leadershipElector) 
+		? new settings.leadershipElector(self)
+		: new leadership.BasicLeadershipElection(self);
+
 	//this is for backwards compatibilty with v0.1.0
 	//TODO: should be removed in the next major release
 	if (options.ignore === false) {
@@ -179,11 +183,18 @@ function Discover (options, callback) {
 			//new node found
 
 			self.emit("added", node, obj, rinfo);
-			self.leadershipElector.onNodeAdded(node, obj, rinfo);
 		}
 
-		self.emit("helloReceived", node);
-		self.leadershipElector.helloReceived(node, isNew, wasMaster, obj, rinfo);
+		if (node.isMaster) {
+			//if we have this node and it was not previously a master then it is a new master node
+			if ((isNew || !wasMaster )) {
+				//this is a new master
+
+				self.emit("master", node, obj, rinfo);
+			}
+		}
+
+		self.emit("helloReceived", node, obj, rinfo, isNew, wasMaster);
 	};
 
 	self.broadcast.on("hello", self.evaluateHello);
@@ -205,10 +216,10 @@ function Discover (options, callback) {
 				//delete the node from our nodes list
 				delete self.nodes[processUuid];
 				self.emit("removed", node);
-				self.leadershipElector.onNodeRemoved(node, processUuid);
 			}
 		}
-		self.leadershipElector.check();
+		
+		self.emit('check');
 	};
 
 	self.start = function (callback) {
@@ -217,31 +228,27 @@ function Discover (options, callback) {
 
 			return false;
 		}
-
-		self.leadershipElector.start(self, function (err) {
+		
+		self.broadcast.start(function (err) {
 			if (err) {
-				callback && callback(err);
-				return;
+				return callback && callback(err, false);
 			}
-			self.broadcast.start(function (err) {
-				if (err) {
-					return callback && callback(err, false);
-				}
 
-				running = true;
+			running = true;
 
-				checkId = setInterval(self.check, checkInterval());
+			checkId = setInterval(self.check, checkInterval());
 
-				if (self.settings.server) {
-					//send hello every helloInterval
-					helloId = setInterval(function () {
-						self.hello();
-					}, helloInterval());
+			if (self.settings.server) {
+				//send hello every helloInterval
+				helloId = setInterval(function () {
 					self.hello();
-				}
+				}, helloInterval());
+				self.hello();
+			}
 
-				return callback && callback(null, true);
-			});
+			self.emit('started');
+
+			return callback && callback(null, true);
 		});
 	};
 
@@ -251,15 +258,14 @@ function Discover (options, callback) {
 		}
 
 		self.broadcast.stop();
-		self.leadershipElector.stop();
 
 		clearInterval(checkId);
 		clearInterval(helloId);
 
+		self.emit('stopped');
+
 		running = false;
 	};
-
-	self.leadershipElector = settings.leadershipElector || new leadership.BasicLeadershipElection();
 
 	self.start(callback);
 
@@ -299,6 +305,12 @@ Discover.prototype.demote = function (permanent) {
 	self.emit("demotion", self.me);
 	self.hello();
 };
+
+Discover.prototype.master = function (node) {
+	var self = this;
+
+	self.emit('master', node)
+}
 
 Discover.prototype.hello = function () {
 	var self = this;

--- a/lib/leadership.js
+++ b/lib/leadership.js
@@ -5,18 +5,18 @@
  */
 function NoLeadershipElection() {
 }
-NoLeadershipElection.prototype.onNodeAdded = function (node) {
+NoLeadershipElection.prototype.onNodeAdded = function (node, obj, rinfo) {
 };
 NoLeadershipElection.prototype.onNodeRemoved = function (node) {
 };
-NoLeadershipElection.prototype.helloReceived = function (node, isNew, wasMaster, obj, rinfo) {
+NoLeadershipElection.prototype.onMasterAdded = function (node, obj, rinfo) {
+};
+NoLeadershipElection.prototype.helloReceived = function (node, obj, rinfo, isNew, wasMaster) {
 };
 NoLeadershipElection.prototype.check = function () {
 };
-NoLeadershipElection.prototype.start = function (callback) {
-	callback();
+NoLeadershipElection.prototype.start = function () {
 };
-
 NoLeadershipElection.prototype.stop = function () {
 };
 
@@ -25,27 +25,32 @@ NoLeadershipElection.prototype.stop = function () {
  * Simple default leadership election.
  * @constructor
  */
-function BasicLeadershipElection() {
+function BasicLeadershipElection(discover) {
+	var self = this;
+
+	self.discover = discover;
+
+	discover.on('started', self.start.bind(self));
+	discover.on('stopped', self.stop.bind(self));
+
+	discover.on('added', self.onNodeAdded.bind(self));
+	discover.on('removed', self.onNodeRemoved.bind(self));
+	discover.on('helloReceived', self.helloReceived.bind(self));
+	discover.on('master', self.onMasterAdded.bind(self));
+	discover.on('check', self.check.bind(self));
 }
-BasicLeadershipElection.prototype.onNodeAdded = function (node) {
 
+BasicLeadershipElection.prototype.onNodeAdded = function (node, obj, rinfo) {
 };
+
 BasicLeadershipElection.prototype.onNodeRemoved = function (node) {
-	this.check();
 };
 
-
-BasicLeadershipElection.prototype.helloReceived = function (node, isNew, wasMaster, obj, rinfo) {
-	var discover = this.discover;
-
-	if (!node.isMaster || (!isNew && wasMaster)) {
-		return;
-	}
-
-	this.check();
-	discover.emit("master", node, obj, rinfo);
+BasicLeadershipElection.prototype.onMasterAdded = function (node, obj, rinfo) {
 };
 
+BasicLeadershipElection.prototype.helloReceived = function (node, obj, rinfo, isNew, wasMaster) {
+};
 
 BasicLeadershipElection.prototype.check = function () {
 	var mastersFound = 0, higherWeightMasters = 0, higherWeightFound = false;
@@ -82,13 +87,10 @@ BasicLeadershipElection.prototype.check = function () {
 	}
 };
 
-BasicLeadershipElection.prototype.start = function (discover, callback) {
-	this.discover = discover;
-	callback();
+BasicLeadershipElection.prototype.start = function () {
 };
 
 BasicLeadershipElection.prototype.stop = function () {
-
 };
 
 module.exports = {

--- a/lib/leadership.js
+++ b/lib/leadership.js
@@ -15,7 +15,7 @@ function resolveLeadership (leadershipElector, discover) {
 	if (leadershipElector === false) {
 		elector = false;
 	}
-	else if (leadershipElector == null || leadershipElector == undefined) {
+	else if (leadershipElector == null) {
 		elector = new BasicLeadershipElection(discover);
 	}
 	else if (typeof leadershipElector == 'function') {

--- a/lib/leadership.js
+++ b/lib/leadership.js
@@ -1,3 +1,47 @@
+module.exports = resolveLeadership;
+module.exports.NoLeadershipElection = NoLeadershipElection;
+module.exports.BasicLeadershipElection = BasicLeadershipElection;
+
+/**
+ * Resolve the leadershipElector for the discover instance
+ *
+ * @param {*} leadershipElector a LeadershipElection instance or constructor, or false to disable
+ * @param {*} discover the discover instance from which events will be bound to LeadershipElection instance methods
+ * @returns {LeadershipElection} the instance of the LeadershipElection module that was resolved or false
+ */
+function resolveLeadership (leadershipElector, discover) {
+	let elector;
+
+	if (leadershipElector === false) {
+		elector = false;
+	}
+	else if (leadershipElector == null || leadershipElector == undefined) {
+		elector = new BasicLeadershipElection(discover);
+	}
+	else if (typeof leadershipElector == 'function') {
+		elector = new leadershipElector(discover);
+	}
+	else {
+		//assume an instance of a leadership elector
+		elector = leadershipElector;
+	}
+
+	if (!elector) {
+		return;
+	}
+
+	discover.on('started', elector.start.bind(elector));
+	discover.on('stopped', elector.stop.bind(elector));
+
+	discover.on('added', elector.onNodeAdded.bind(elector));
+	discover.on('removed', elector.onNodeRemoved.bind(elector));
+	discover.on('helloReceived', elector.helloReceived.bind(elector));
+	discover.on('master', elector.onMasterAdded.bind(elector));
+	discover.on('check', elector.check.bind(elector));
+
+	return elector;
+}
+
 /**
  * No leadership election
  * @param discover
@@ -29,15 +73,6 @@ function BasicLeadershipElection(discover) {
 	var self = this;
 
 	self.discover = discover;
-
-	discover.on('started', self.start.bind(self));
-	discover.on('stopped', self.stop.bind(self));
-
-	discover.on('added', self.onNodeAdded.bind(self));
-	discover.on('removed', self.onNodeRemoved.bind(self));
-	discover.on('helloReceived', self.helloReceived.bind(self));
-	discover.on('master', self.onMasterAdded.bind(self));
-	discover.on('check', self.check.bind(self));
 }
 
 BasicLeadershipElection.prototype.onNodeAdded = function (node, obj, rinfo) {
@@ -91,9 +126,4 @@ BasicLeadershipElection.prototype.start = function () {
 };
 
 BasicLeadershipElection.prototype.stop = function () {
-};
-
-module.exports = {
-	NoLeadershipElection: NoLeadershipElection,
-	BasicLeadershipElection: BasicLeadershipElection
 };

--- a/lib/leadership.js
+++ b/lib/leadership.js
@@ -122,7 +122,8 @@ BasicLeadershipElection.prototype.check = function () {
 	}
 };
 
-BasicLeadershipElection.prototype.start = function () {
+BasicLeadershipElection.prototype.start = function (discover) {
+	this.discover = discover;
 };
 
 BasicLeadershipElection.prototype.stop = function () {


### PR DESCRIPTION
It is not totally necessary to create a whole new class/interface to
manage the leadership. With the addition of a few new events, it's
possible to wire everything up just using events. I feel like this
makes it more generic as well.

This commit removes most of the internal references to leadershipElector
and modifies the BasicLeadershipElection class to accept the node-discover
instance in the constructor. The constructor then wires all the events to
the class methods.

This restores the expected behavior that is reported in #36

ref: #36, #35, #34


@aikar Would this still work with what you needed?