### PR TITLE
performance: Cache hello packet encoding/decoding

### DIFF
--- a/lib/discover.js
+++ b/lib/discover.js
@@ -351,7 +351,7 @@ Discover.prototype.master = function (node) {
 	var self = this;
 
 	self.emit('master', node)
-}
+};
 
 Discover.prototype.hello = function () {
 	var self = this;
@@ -364,6 +364,7 @@ Discover.prototype.advertise = function (obj) {
 	var self = this;
 
 	self.me.advertisement = obj;
+	self.broadcast.helloCache = null;
 };
 
 Discover.prototype.eachNode = function (fn) {

--- a/lib/network.js
+++ b/lib/network.js
@@ -31,6 +31,8 @@ function Network (options) {
     self.ignoreProcess  = (options.ignoreProcess ===  false) ? false : true;
     self.ignoreInstance = (options.ignoreInstance ===  false) ? false : true;
     self.hostName       = options.hostname || options.hostName || hostName;
+    self.helloCache = null;
+    self.helloReceiveCache = {};
 
     if (nodeVersion[0] === 0 && nodeVersion[1] < 12) {
         //node v0.10 does not support passing an object to dgram.createSocket
@@ -69,7 +71,7 @@ function Network (options) {
             else {
                 self.emit("message", obj)
             }
-        });
+        }, rinfo);
     });
 
     self.on("error", function (err) {
@@ -159,10 +161,14 @@ Network.prototype.send = function (event) {
                 , destination
             );
         });
-    });
+    }, event);
 };
 
-Network.prototype.encode = function (data, callback) {
+Network.prototype.encode = function (data, callback, event) {
+    var isHello = event === "hello";
+    if (isHello && this.helloCache) {
+        return callback(null, this.helloCache);
+    }
     var self = this
         , tmp
         ;
@@ -172,6 +178,9 @@ Network.prototype.encode = function (data, callback) {
             ? encrypt(JSON.stringify(data),self.key)
             : JSON.stringify(data)
             ;
+        if (isHello) {
+            self.helloCache = tmp;
+        }
     }
     catch (e) {
         return callback(e, null);
@@ -180,17 +189,32 @@ Network.prototype.encode = function (data, callback) {
     return callback(null, tmp);
 };
 
-Network.prototype.decode = function (data, callback) {
+Network.prototype.decode = function (data, callback, rinfo) {
     var self = this
         , tmp
         ;
-
+    var cacheKey = rinfo.address + ":" + rinfo.port;
+    var cached = self.helloReceiveCache[cacheKey];
+    data = data.toString();
+    if (cached) {
+        for (var i = 0; i < cached.length; i++) {
+            if (cached[i]['data'] === data) {
+                return callback(null, cached[i]['decoded']);
+            }
+        }
+    }
     try {
         if (self.key) {
-        tmp = JSON.parse(decrypt(data.toString(),self.key));
+        tmp = JSON.parse(decrypt(data,self.key));
         }
         else {
             tmp = JSON.parse(data);
+        }
+        if (tmp && tmp.event === "hello") {
+            self.helloReceiveCache[cacheKey] = (self.helloReceiveCache[cacheKey] || []).filter(function (cache) {
+                return cache['decoded'].iid !== tmp.iid;
+            });
+            self.helloReceiveCache[cacheKey].push({data: data, decoded: tmp});
         }
     }
     catch (e) {


### PR DESCRIPTION
Hello packets for the most part will never change. JSON and encryption are blocking operations
that occur some performance cost to use.

We can cache our outgoing hello packet, and clear the cache anytime the payload is expected
to be manipulated by .advertise().

Likewise, we can cache received hello messages based on IP+Port+data.

The size of these messages are small and should result in negligible memory increase, but
at the benefit of a major reduction in CPU cost to avoid repeatedly calling
encrypt/encrypt and JSON stringify/parse.

In a large ensemble of nodes, this can add significant CPU reduction.